### PR TITLE
Update main.scss

### DIFF
--- a/packages/com.sncommunity.dracula-theme/src/main.scss
+++ b/packages/com.sncommunity.dracula-theme/src/main.scss
@@ -77,3 +77,20 @@
 #plus-editor label kbd {
   background-color: var(--sn-stylekit-background-color);
 }
+
+::-webkit-scrollbar {
+    background-color: rgb(10 10 10);
+}
+
+::-webkit-scrollbar-track {
+    background-color: rgb(30 30 30);
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: rgb(90 90 90);
+}
+
+select {
+  color: rgb(110, 159, 31);
+  background-color: rgb(10 10 10);
+}


### PR DESCRIPTION
On MacOS the select element and the electron/chrome toolbars are white and distract from the dark theme, these changes make these elements fit the theme