### PR TITLE
simple-task-editor: Prevent adding empty task

### DIFF
--- a/packages/org.standardnotes.simple-task-editor/app/components/CreateTask.js
+++ b/packages/org.standardnotes.simple-task-editor/app/components/CreateTask.js
@@ -32,7 +32,8 @@ export default class CreateTask extends React.Component {
   handleKeyPress = (event) => {
     if (event.key === 'Enter') {
       var rawString = event.target.value;
-      this.submitTask(rawString);
+      if(rawString)
+        this.submitTask(rawString);
     }
   }
 


### PR DESCRIPTION
Add a check if empty to prevent to add an empty task on the Checklist (org.standardnotes.simple-task-editor) plugin