### PR TITLE
fix(SNOTES-473): code editor fixes

### DIFF
--- a/packages/org.standardnotes.code-editor/index.html
+++ b/packages/org.standardnotes.code-editor/index.html
@@ -28,32 +28,29 @@
     <script src="dist/lib/component-relay.js"></script>
     <!-- Required for styling selected text -->
     <script src="dist/codemirror/addon/selection/mark-selection.js"></script>
-    <script>
-      CodeMirror.modeURL = "dist/codemirror/mode/%N/%N.js";
-    </script>
   </head>
 
   <body class="sn-component">
     <div class="wrapper">
       <textarea id="code" name="code"></textarea>
     <div>
-    <div class="sk-app-bar no-edges no-bottom-edge" style="width: inherit;">
+    <div id="bar" class="sk-app-bar no-edges no-bottom-edge">
       <div class="left">
         <div class="sk-app-bar-item no-pointer">
           <span class="sk-p">Language:</span>
         </div>
         <div class="sk-app-bar-item no-pointer">
-          <select id="language-select" onchange="onLanguageSelect(event)"></select>
+          <select id="language-select"></select>
         </div>
         <div class="sk-app-bar-item">
-          <span id="default-label" class="sk-label" onclick="setDefaultLanguage(event)">Set as Default</span>
+          <span id="default-label" class="sk-label">Set as Default</span>
         </div>
       </div>
       <div class="center"></div>
       <div class="right">
         <div class="sk-app-bar-item no-pointer border"></div>
         <div class="sk-app-bar-item">
-          <span id="toggle-vim-mode-button" class="sk-label" onclick="toggleVimMode()">Enable Vim mode</span>
+          <span id="toggle-vim-mode-button" class="sk-label">Enable Vim mode</span>
         </div>
       </div>
     </div>

--- a/packages/org.standardnotes.code-editor/src/main.js
+++ b/packages/org.standardnotes.code-editor/src/main.js
@@ -1,3 +1,5 @@
+CodeMirror.modeURL = "dist/codemirror/mode/%N/%N.js";
+
 document.addEventListener('DOMContentLoaded', function () {
   const modeByModeMode = CodeMirror.modeInfo.reduce(function (acc, m) {
     if (acc[m.mode]) {
@@ -163,13 +165,15 @@ document.addEventListener('DOMContentLoaded', function () {
     updateVimStatus(keymap)
   }
 
-  window.onLanguageSelect = function () {
+  function onLanguageSelect() {
     const language = modes[select.selectedIndex]
     changeMode(language)
     saveNote()
   }
 
-  window.setDefaultLanguage = function () {
+  document.getElementById('language-select').addEventListener('change', onLanguageSelect)
+
+  function setDefaultLanguage() {
     const language = modes[select.selectedIndex]
 
     // assign default language for this editor when entering notes
@@ -186,6 +190,8 @@ document.addEventListener('DOMContentLoaded', function () {
       message.innerHTML = original
     }, 750)
   }
+
+  document.getElementById('default-label').addEventListener('click', setDefaultLanguage)
 
   function inputModeToMode(inputMode) {
     const convertCodeMirrorMode = function (codeMirrorMode) {
@@ -260,7 +266,7 @@ document.addEventListener('DOMContentLoaded', function () {
     toggleButton.classList.add(buttonClass)
   }
 
-  window.toggleVimMode = function () {
+  function toggleVimMode() {
     let newKeyMap
 
     const currentKeyMap = componentRelay.getComponentDataValueForKey('keyMap') ?? 'default'
@@ -273,6 +279,8 @@ document.addEventListener('DOMContentLoaded', function () {
     window.setKeyMap(newKeyMap)
     componentRelay.setComponentDataValueForKey('keyMap', newKeyMap)
   }
+
+  document.getElementById('toggle-vim-mode-button').addEventListener('click', toggleVimMode)
 
   function getInputStyleForEnvironment() {
     const environment = componentRelay.environment ?? 'web'

--- a/packages/org.standardnotes.code-editor/src/main.scss
+++ b/packages/org.standardnotes.code-editor/src/main.scss
@@ -103,3 +103,7 @@ body, html {
 .cm-fat-cursor .CodeMirror-line > span[role="presentation"] {
   caret-color: transparent;
 }
+
+#bar {
+  width: inherit;
+}


### PR DESCRIPTION
Fixed errors in code editor:
- `Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self'`, fixed by removing inline event handlers from the HTML file and setting up event listeners on the JS file instead.
- `Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'self'`, fixed by moving contents of inline script to JS file.
- `Refused to apply inline style because it violates the following Content Security Policy directive: "style-src *".`, fixed by setting style in CSS file instead of using inline styling.

This fixes the "Enable Vim mode" button not working, as well as the language dropdown/default language setter button.